### PR TITLE
fix chrome web store link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Heart React for Messenger
 ### Adds the ❤❤ heart ❤❤ reaction to Facebook Messenger reactions
 
-[Chrome Web Store Listing](https://chrome.google.com/webstore/detail/ohhhckeljnecaiamhlahbpdccchbofgl/publish-accepted?authuser=1&hl=en)
+[Chrome Web Store Listing](https://chrome.google.com/webstore/detail/heart-react-for-messenger/ohhhckeljnecaiamhlahbpdccchbofgl)
 
 Normally the heart react is only visible to a select few individuals.  
 However, this extension unlocks the heart reaction capabilities for all users.  


### PR DESCRIPTION
Previous link contained "publish-accepted" and the install button couldn't be clicked.